### PR TITLE
Fix WebSocket connection through Cloudflare by forcing HTTP/1.1

### DIFF
--- a/internal/computing/ecp2_client.go
+++ b/internal/computing/ecp2_client.go
@@ -1,6 +1,7 @@
 package computing
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -231,6 +232,9 @@ func (c *ECP2Client) Stop() {
 func (c *ECP2Client) connect() error {
 	dialer := websocket.Dialer{
 		HandshakeTimeout: 10 * time.Second,
+		TLSClientConfig: &tls.Config{
+			NextProtos: []string{"http/1.1"}, // Force HTTP/1.1 to enable WebSocket upgrade through Cloudflare
+		},
 	}
 
 	conn, _, err := dialer.Dial(c.wsURL+"/ws", nil)


### PR DESCRIPTION
## Summary
- Cloudflare negotiates HTTP/2 by default via TLS ALPN
- HTTP/2 doesn't support the traditional WebSocket Upgrade mechanism, causing "bad handshake" errors
- This fix configures the WebSocket dialer to request HTTP/1.1 during TLS negotiation

## Changes
- Add `crypto/tls` import
- Add `TLSClientConfig` with `NextProtos: []string{"http/1.1"}` to force HTTP/1.1

## Test plan
- [x] Tested on production server connecting to `wss://inference-ws.swanchain.io/ws`
- [x] Verified WebSocket connection succeeds after fix
- [x] Confirmed provider registration and heartbeat working