### PR TITLE
fix: stop stale pump goroutines on WebSocket reconnect

### DIFF
--- a/internal/computing/inference_client.go
+++ b/internal/computing/inference_client.go
@@ -228,6 +228,7 @@ type InferenceClient struct {
 	conn                      *websocket.Conn
 	send                      chan []byte
 	stopCh                    chan struct{}
+	pumpDone                  chan struct{} // Signals current readPump/writePump to stop on reconnect
 	registered                bool
 	inferenceHandler          InferenceHandler
 	streamingInferenceHandler StreamingInferenceHandler
@@ -293,6 +294,7 @@ func NewInferenceClient(nodeID, workerAddr, ownerAddr string) *InferenceClient {
 		serviceURL:   serviceURL,
 		send:         make(chan []byte, 256),
 		stopCh:       make(chan struct{}),
+		pumpDone:     make(chan struct{}),
 		metrics:      NewInferenceMetrics(),
 		gpuCollector: NewGPUMetricsCollector(),
 	}
@@ -445,8 +447,11 @@ func (c *InferenceClient) Start() error {
 	}
 
 	// Start read/write pumps
-	go c.readPump()
-	go c.writePump()
+	c.mu.RLock()
+	done := c.pumpDone
+	c.mu.RUnlock()
+	go c.readPumpWithDone(done)
+	go c.writePumpWithDone(done)
 	go c.heartbeatPump()
 
 	// Send registration
@@ -495,6 +500,15 @@ func (c *InferenceClient) reconnect() {
 	c.metrics.RecordConnectionState("reconnecting")
 	c.metrics.RecordReconnect()
 
+	// Stop old readPump/writePump goroutines by closing pumpDone, then create a new one
+	c.mu.Lock()
+	close(c.pumpDone)
+	c.pumpDone = make(chan struct{})
+	if c.conn != nil {
+		c.conn.Close()
+	}
+	c.mu.Unlock()
+
 	// Reset send failure counter so reconnected state starts clean
 	c.resetSendFailures()
 
@@ -542,9 +556,12 @@ func (c *InferenceClient) reconnect() {
 				logs.GetLogger().Infof("Drained %d stale messages from send buffer after reconnect", drainCount)
 			}
 
-			// Restart pumps
-			go c.readPump()
-			go c.writePump()
+			// Restart pumps with current pumpDone channel
+			c.mu.RLock()
+			done := c.pumpDone
+			c.mu.RUnlock()
+			go c.readPumpWithDone(done)
+			go c.writePumpWithDone(done)
 			return
 		}
 	}
@@ -836,7 +853,7 @@ func (c *InferenceClient) register() error {
 	return nil
 }
 
-func (c *InferenceClient) readPump() {
+func (c *InferenceClient) readPumpWithDone(done <-chan struct{}) {
 	defer func() {
 		c.mu.Lock()
 		if c.conn != nil {
@@ -856,9 +873,17 @@ func (c *InferenceClient) readPump() {
 		select {
 		case <-c.stopCh:
 			return
+		case <-done:
+			return
 		default:
 			_, message, err := c.conn.ReadMessage()
 			if err != nil {
+				// If pumpDone was closed, another goroutine is already reconnecting
+				select {
+				case <-done:
+					return
+				default:
+				}
 				if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
 					logs.GetLogger().Errorf("WebSocket read error: %v", err)
 				}
@@ -877,21 +902,17 @@ func (c *InferenceClient) readPump() {
 	}
 }
 
-func (c *InferenceClient) writePump() {
+func (c *InferenceClient) writePumpWithDone(done <-chan struct{}) {
 	ticker := time.NewTicker(pingPeriod)
 	defer func() {
 		ticker.Stop()
-		// Close connection so readPump detects failure immediately
-		c.mu.Lock()
-		if c.conn != nil {
-			c.conn.Close()
-		}
-		c.mu.Unlock()
 	}()
 
 	for {
 		select {
 		case <-c.stopCh:
+			return
+		case <-done:
 			return
 		case message := <-c.send:
 			c.mu.RLock()


### PR DESCRIPTION
## Summary
- Use a per-connection `pumpDone` channel to signal old `readPump`/`writePump` goroutines to exit on reconnect
- Prevents goroutine leak where stale pumps write to closed connections, eventually deadlocking the process
- `writePump` no longer closes the connection in its defer, which was killing newly established connections

## Problem
After WebSocket reconnect, old `readPump`/`writePump` goroutines kept running. They would write to the closed connection (`WebSocket write error: use of closed network connection`), and the `writePump` defer would close `c.conn` — which by then pointed to the **new** connection. This caused cascading reconnects and eventually a full deadlock (process alive but no heartbeats or log output for hours).

Observed on provider `192.168.61.114` (4x RTX 3090): process hung at 43 threads with no output for 2+ hours.

## Test plan
- [x] Builds successfully
- [x] Existing tests pass
- [ ] Deploy to provider and monitor reconnect behavior under load

Fixes #27