### PR TITLE
fix: guard against concurrent reconnects

### DIFF
--- a/internal/computing/inference_client.go
+++ b/internal/computing/inference_client.go
@@ -249,6 +249,10 @@ type InferenceClient struct {
 	sendFailures     int        // Consecutive send buffer full timeouts
 	sendFailuresMu   sync.Mutex // Protects sendFailures counter
 
+	// Reconnect guard
+	reconnecting     bool       // True while a reconnect is in progress
+	reconnectMu      sync.Mutex // Protects reconnecting flag
+
 	// Metrics tracking
 	metrics      *InferenceMetrics
 	gpuCollector *GPUMetricsCollector
@@ -497,6 +501,20 @@ func (c *InferenceClient) connect() error {
 }
 
 func (c *InferenceClient) reconnect() {
+	// Guard against concurrent reconnects from readPump and heartbeatPump
+	c.reconnectMu.Lock()
+	if c.reconnecting {
+		c.reconnectMu.Unlock()
+		return
+	}
+	c.reconnecting = true
+	c.reconnectMu.Unlock()
+	defer func() {
+		c.reconnectMu.Lock()
+		c.reconnecting = false
+		c.reconnectMu.Unlock()
+	}()
+
 	c.metrics.RecordConnectionState("reconnecting")
 	c.metrics.RecordReconnect()
 


### PR DESCRIPTION
## Summary
- Add a `reconnecting` flag to prevent concurrent reconnects from `readPump` and `heartbeatPump`
- Both can trigger `reconnect()` independently, causing a double-reconnect race where the second kills the first's newly started pumps, leaving the connection in a zombie state (connected but not receiving messages)

## Problem
After deploying #28, the goroutine leak was fixed but a new issue appeared: two reconnects triggered within 10 seconds of each other. The second reconnect closed the first's `pumpDone`, killing its new pumps. After the second reconnect completed, no heartbeats or inference requests were received despite the connection being established.

```
15:59:14 - Reconnect #1: connected, registered, drained 29 stale messages
15:59:24 - Reconnect #2: triggered, closed #1's pumpDone, connected after 2 retries
16:00+   - No heartbeats, no inference requests (zombie state)
```

## Test plan
- [x] Builds successfully
- [x] Existing tests pass
- [ ] Monitor provider reconnect behavior under load

Fixes #27