### PR TITLE
fix: start pumps before register on reconnect

### DIFF
--- a/internal/computing/inference_client.go
+++ b/internal/computing/inference_client.go
@@ -553,13 +553,7 @@ func (c *InferenceClient) reconnect() {
 				continue
 			}
 
-			// Re-register after reconnection
-			if err := c.register(); err != nil {
-				logs.GetLogger().Errorf("Re-registration failed: %v", err)
-				continue
-			}
-
-			// Drain any stale messages from send buffer after reconnect
+			// Drain any stale messages from send buffer before starting new pumps
 			drainCount := 0
 		drainLoop:
 			for {
@@ -574,12 +568,27 @@ func (c *InferenceClient) reconnect() {
 				logs.GetLogger().Infof("Drained %d stale messages from send buffer after reconnect", drainCount)
 			}
 
-			// Restart pumps with current pumpDone channel
+			// Start pumps before registering so the writePump can send the registration message
 			c.mu.RLock()
 			done := c.pumpDone
 			c.mu.RUnlock()
 			go c.readPumpWithDone(done)
 			go c.writePumpWithDone(done)
+
+			// Re-register after reconnection
+			if err := c.register(); err != nil {
+				logs.GetLogger().Errorf("Re-registration failed: %v", err)
+				// Stop the pumps we just started before retrying
+				c.mu.Lock()
+				close(c.pumpDone)
+				c.pumpDone = make(chan struct{})
+				if c.conn != nil {
+					c.conn.Close()
+				}
+				c.mu.Unlock()
+				continue
+			}
+
 			return
 		}
 	}


### PR DESCRIPTION
## Summary
- Reorder reconnect sequence to: drain stale messages → start pumps → register
- Previously, `register()` was called before pumps started, so the registration message went into the send buffer with no `writePump` to send it, then got drained as "stale"
- This caused the server to never receive the registration, leaving models offline after reconnect

## Verified
Tested by redeploying Swan Inference server — both reconnects now get `Registration successful` and inference requests resume immediately:
```
16:34:39 - Connected, drained 5 stale, registered → Registration successful ✓
16:34:41 - Second reconnect (bad handshake x2, then connected)
16:34:45 - Registered → Registration successful ✓
16:34:46 - Processing inference requests ✓
```