### PR TITLE
feat: use build-time ldflags for inference URLs instead of hardcoded …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,14 @@ unexport GOFLAGS
 
 GOCC?=go
 
-ldflags=-X=github.com/swanchain/go-computing-provider/build.CurrentCommit=+git.$(subst -,.,$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null))
+PKG=github.com/swanchain/computing-provider-v2/build
+
+ldflags=-X=$(PKG).CurrentCommit=+git.$(subst -,.,$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null))
+
+# Dev/testnet inference URL overrides
+dev_ldflags=-X $(PKG).DefaultInferenceURL=https://inference-dev.swanchain.io \
+            -X $(PKG).DefaultInferenceWSURL=wss://inference-ws-dev.swanchain.io \
+            -X $(PKG).DefaultInferenceAPIURL=https://inference-dev.swanchain.io/api/v1
 
 all: mainnet
 .PHONY: all
@@ -23,30 +30,30 @@ clean:
 	sudo rm -rf /usr/local/bin/computing-provider
 .PHONY: clean
 
-mainnet: GOFLAGS+= -ldflags="$(ldflags) -X github.com/swanchain/go-computing-provider/build.NetWorkTag=mainnet"
+mainnet: GOFLAGS+= -ldflags="$(ldflags) -X $(PKG).NetWorkTag=mainnet"
 mainnet: computing-provider
 
-testnet: GOFLAGS+= -ldflags="$(ldflags) -X github.com/swanchain/go-computing-provider/build.NetWorkTag=testnet"
+testnet: GOFLAGS+= -ldflags="$(ldflags) -X $(PKG).NetWorkTag=testnet $(dev_ldflags)"
 testnet: computing-provider
 
 # Darwin ARM64 (Apple Silicon) builds
 darwin-arm64:
 	rm -rf computing-provider-darwin-arm64
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X github.com/swanchain/go-computing-provider/build.NetWorkTag=mainnet" -o computing-provider-darwin-arm64 ./cmd/computing-provider
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=mainnet" -o computing-provider-darwin-arm64 ./cmd/computing-provider
 .PHONY: darwin-arm64
 
 darwin-arm64-testnet:
 	rm -rf computing-provider-darwin-arm64
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X github.com/swanchain/go-computing-provider/build.NetWorkTag=testnet" -o computing-provider-darwin-arm64 ./cmd/computing-provider
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=testnet $(dev_ldflags)" -o computing-provider-darwin-arm64 ./cmd/computing-provider
 .PHONY: darwin-arm64-testnet
 
 # Linux ARM64 builds
 linux-arm64:
 	rm -rf computing-provider-linux-arm64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X github.com/swanchain/go-computing-provider/build.NetWorkTag=mainnet" -o computing-provider-linux-arm64 ./cmd/computing-provider
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=mainnet" -o computing-provider-linux-arm64 ./cmd/computing-provider
 .PHONY: linux-arm64
 
 linux-arm64-testnet:
 	rm -rf computing-provider-linux-arm64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X github.com/swanchain/go-computing-provider/build.NetWorkTag=testnet" -o computing-provider-linux-arm64 ./cmd/computing-provider
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=testnet $(dev_ldflags)" -o computing-provider-linux-arm64 ./cmd/computing-provider
 .PHONY: linux-arm64-testnet

--- a/build/version.go
+++ b/build/version.go
@@ -10,6 +10,12 @@ var CurrentCommit string
 
 var NetWorkTag string
 
+// Inference URL defaults — overridable via ldflags at build time.
+// Production defaults; dev builds override these in the Makefile.
+var DefaultInferenceURL = "https://api.swanchain.io/v1"
+var DefaultInferenceWSURL = "wss://api-ws.swanchain.io"
+var DefaultInferenceAPIURL = "https://api.swanchain.io/v1"
+
 const BuildVersion = "0.1.0"
 
 const UBITaskImageIntelCpu = "swanhub/ubi-worker-cpu-intel:latest"

--- a/cmd/computing-provider/auth.go
+++ b/cmd/computing-provider/auth.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/swanchain/computing-provider-v2/build"
 	"github.com/swanchain/computing-provider-v2/conf"
 	"github.com/swanchain/computing-provider-v2/internal/setup"
 )
@@ -155,7 +156,7 @@ func handleExistingProviderLogin(cpRepoPath string, prompter *setup.Prompter, au
 		setup.PrintError(fmt.Sprintf("Failed to create provider key: %v", err))
 		fmt.Println()
 		fmt.Println("If you have an existing API key, you can enter it manually.")
-		fmt.Println("You can also manage your keys at https://inference-dev.swanchain.io")
+		fmt.Println("You can also manage your keys at " + build.DefaultInferenceURL)
 		fmt.Println()
 
 		// Fall back to manual entry

--- a/cmd/computing-provider/inference.go
+++ b/cmd/computing-provider/inference.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/mitchellh/go-homedir"
 	"github.com/olekukonko/tablewriter"
+	"github.com/swanchain/computing-provider-v2/build"
 	"github.com/swanchain/computing-provider-v2/conf"
 	"github.com/swanchain/computing-provider-v2/internal/computing"
 	"github.com/swanchain/computing-provider-v2/internal/setup"
@@ -99,7 +100,7 @@ func getServiceURL(cfg *conf.ComputeNode) string {
 	if serviceURL == "" {
 		wsURL := cfg.Inference.WebSocketURL
 		if wsURL == "" {
-			wsURL = "wss://inference.swanchain.io/ws"
+			wsURL = build.DefaultInferenceWSURL
 		}
 		serviceURL = strings.Replace(wsURL, "wss://", "https://", 1)
 		serviceURL = strings.Replace(serviceURL, "ws://", "http://", 1)
@@ -468,7 +469,7 @@ var inferenceStatusCmd = &cli.Command{
 			fmt.Println("  computing-provider inference keygen")
 			fmt.Println()
 			fmt.Println("Or manually:")
-			fmt.Println("  1. Sign up at https://inference.swanchain.io or via API")
+			fmt.Println("  1. Sign up at " + build.DefaultInferenceURL + " or via API")
 			fmt.Println("  2. Add your API key to config.toml [Inference] section")
 			fmt.Println("  3. Or set: export INFERENCE_API_KEY=sk-prov-xxxxxxxxxxxxxxxxxxxx")
 			fmt.Println()

--- a/cmd/computing-provider/models.go
+++ b/cmd/computing-provider/models.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/mitchellh/go-homedir"
 	"github.com/olekukonko/tablewriter"
+	"github.com/swanchain/computing-provider-v2/build"
 	"github.com/swanchain/computing-provider-v2/conf"
 	"github.com/swanchain/computing-provider-v2/internal/models"
 	"github.com/urfave/cli/v2"
@@ -140,7 +141,7 @@ Examples:
 		},
 		&cli.StringFlag{
 			Name:  "service-url",
-			Usage: "Swan Inference API URL (default: from config or https://inference.swanchain.io)",
+			Usage: "Swan Inference API URL (default: from config or " + build.DefaultInferenceURL + ")",
 		},
 	},
 	Action: func(cctx *cli.Context) error {
@@ -356,7 +357,7 @@ func getModelsServiceURL(cctx *cli.Context) string {
 		}
 	}
 
-	return "https://inference.swanchain.io"
+	return build.DefaultInferenceURL
 }
 
 func humanSizeCP(b int64) string {

--- a/conf/config.go
+++ b/conf/config.go
@@ -466,8 +466,8 @@ func generateDefaultConfig() ComputeNode {
 		},
 		Inference: Inference{
 			Enable:             true, // Inference mode is enabled by default
-			ServiceURL:         "https://inference-dev.swanchain.io",
-			WebSocketURL:       "wss://inference-ws-dev.swanchain.io",
+			ServiceURL:         build.DefaultInferenceURL,
+			WebSocketURL:       build.DefaultInferenceWSURL,
 			Models:             []string{},
 			ChainRPC:           "",
 			CollateralContract: "",

--- a/internal/computing/inference_client.go
+++ b/internal/computing/inference_client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/mitchellh/go-homedir"
+	"github.com/swanchain/computing-provider-v2/build"
 	"github.com/swanchain/computing-provider-v2/conf"
 	"github.com/swanchain/computing-provider-v2/internal/models"
 )
@@ -273,7 +274,7 @@ func NewInferenceClient(nodeID, workerAddr, ownerAddr string) *InferenceClient {
 	serviceURL := config.Inference.ServiceURL
 	if serviceURL == "" {
 		// Derive from WebSocket URL if not configured
-		// e.g., wss://inference-ws-dev.swanchain.io -> https://inference-dev.swanchain.io
+		// Derive HTTP URL from WebSocket URL (e.g., wss://host/ws -> https://host)
 		serviceURL = wsURL
 		serviceURL = strings.Replace(serviceURL, "wss://", "https://", 1)
 		serviceURL = strings.Replace(serviceURL, "ws://", "http://", 1)
@@ -353,7 +354,7 @@ func (c *InferenceClient) checkProviderStatus() (*ProviderStatusResponse, error)
 			CanConnect:  false,
 			Message:     "No API key configured",
 			NextSteps: []string{
-				"1. Sign up at https://inference.swanchain.io or via API",
+				"1. Sign up at " + build.DefaultInferenceURL + " or via API",
 				"2. Add your API key to config.toml [Inference] section",
 				"3. Or set INFERENCE_API_KEY environment variable",
 			},

--- a/internal/setup/auth_client.go
+++ b/internal/setup/auth_client.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/swanchain/computing-provider-v2/build"
 )
 
 // ValidateEVMAddress validates an EVM wallet address format
@@ -30,11 +32,6 @@ func ValidateEVMAddress(addr string) error {
 	return nil
 }
 
-const (
-	// DefaultInferenceAPIURL is the default Swan Inference API URL (dev environment)
-	DefaultInferenceAPIURL = "https://inference-dev.swanchain.io/api/v1"
-)
-
 // AuthClient handles authentication with Swan Inference API
 type AuthClient struct {
 	baseURL    string
@@ -44,7 +41,7 @@ type AuthClient struct {
 // NewAuthClient creates a new auth client
 func NewAuthClient(baseURL string) *AuthClient {
 	if baseURL == "" {
-		baseURL = DefaultInferenceAPIURL
+		baseURL = build.DefaultInferenceAPIURL
 	}
 	return &AuthClient{
 		baseURL: baseURL,

--- a/internal/setup/discovery.go
+++ b/internal/setup/discovery.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/swanchain/computing-provider-v2/build"
 )
 
 // Common inference server ports to scan
@@ -504,7 +506,7 @@ type SwanModel struct {
 // FetchSwanModels fetches the list of supported models from Swan Inference API
 func FetchSwanModels(apiURL string) ([]SwanModel, error) {
 	if apiURL == "" {
-		apiURL = "https://inference-dev.swanchain.io/api/v1"
+		apiURL = build.DefaultInferenceAPIURL
 	}
 
 	client := &http.Client{Timeout: 10 * time.Second}


### PR DESCRIPTION
…values

Replace hardcoded dev/prod inference URLs with build.Default* variables that default to production and are overridden to dev URLs via ldflags in testnet builds. This eliminates branch-specific code and prevents merge conflicts when merging dev -> main.

- make mainnet: prod URLs (https://api.swanchain.io/v1)
- make testnet: dev URLs (https://inference-dev.swanchain.io)
- Fix Makefile ldflags module path (go-computing-provider -> computing-provider-v2)