### PR TITLE
fix: send health update after registration and use separate probe timeouts

### DIFF
--- a/internal/computing/inference_client.go
+++ b/internal/computing/inference_client.go
@@ -1156,11 +1156,22 @@ func (c *InferenceClient) handleMessage(msg Message) {
 		}
 		if payload.Success {
 			c.mu.Lock()
+			wasRegistered := c.registered
 			c.registered = true
 			c.lastHeartbeatAck = time.Now()
 			c.missedAcks = 0
 			c.mu.Unlock()
 			logs.GetLogger().Infof("Registration successful: %s", payload.Message)
+
+			// Send current model health immediately after first registration so the hub
+			// has up-to-date health status. Without this, health updates that fired
+			// while the WebSocket was disconnected are lost and the hub keeps stale state.
+			if !wasRegistered && c.modelHealthProvider != nil {
+				if health := c.modelHealthProvider(); len(health) > 0 {
+					c.SendModelHealthUpdate(health)
+					logs.GetLogger().Infof("Sent post-registration health update for %d models", len(health))
+				}
+			}
 		} else {
 			logs.GetLogger().Warnf("Received failed ack: %s", payload.Message)
 		}

--- a/internal/computing/model_health_checker.go
+++ b/internal/computing/model_health_checker.go
@@ -316,12 +316,19 @@ func (h *ModelHealthChecker) checkModel(modelID string) {
 
 // probeEndpoint performs the actual health check request
 func (h *ModelHealthChecker) probeEndpoint(endpoint, apiKey string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), h.config.Timeout)
-	defer cancel()
+	// Use a short timeout for /health since some proxies (e.g., LiteLLM) have slow health endpoints.
+	// This prevents a hanging /health from consuming the entire timeout budget.
+	healthTimeout := h.config.Timeout / 2
+	if healthTimeout < 3*time.Second {
+		healthTimeout = 3 * time.Second
+	}
 
 	// Try /health endpoint first (common health check endpoint)
+	healthCtx, healthCancel := context.WithTimeout(context.Background(), healthTimeout)
+	defer healthCancel()
+
 	healthURL := endpoint + "/health"
-	req, err := http.NewRequestWithContext(ctx, "GET", healthURL, nil)
+	req, err := http.NewRequestWithContext(healthCtx, "GET", healthURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -338,9 +345,12 @@ func (h *ModelHealthChecker) probeEndpoint(endpoint, apiKey string) error {
 		resp.Body.Close()
 	}
 
-	// Try /v1/models endpoint (OpenAI-compatible)
+	// Try /v1/models endpoint (OpenAI-compatible) with its own timeout
+	modelsCtx, modelsCancel := context.WithTimeout(context.Background(), h.config.Timeout)
+	defer modelsCancel()
+
 	modelsURL := endpoint + "/v1/models"
-	req, err = http.NewRequestWithContext(ctx, "GET", modelsURL, nil)
+	req, err = http.NewRequestWithContext(modelsCtx, "GET", modelsURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Send current model health to the hub immediately after WebSocket registration succeeds. Previously, health updates that fired while disconnected were silently dropped, leaving the hub with stale unhealthy status.
- Use separate timeout contexts for `/health` and `/v1/models` probes in the health checker. Some proxies (e.g., LiteLLM) have slow `/health` endpoints that consumed the entire timeout budget, causing the `/v1/models` fallback to always fail.

## Test plan
- [ ] Deploy to provider running behind LiteLLM proxy
- [ ] Verify `Sent post-registration health update for N models` appears in logs after registration
- [ ] Verify heartbeat acks do NOT trigger redundant health updates
- [ ] Verify models show as healthy on Swan Inference dashboard after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)