### PR TITLE
Release v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,10 @@ git clone https://github.com/swanchain/computing-provider.git
 cd computing-provider
 make clean && make testnet && sudo make install
 
-# 2. Browse available models from the Swan Model Repository
-computing-provider models catalog
-
-# 3. Download verified model weights (e.g., Qwen 2.5 7B)
+# 2. Download model weights from HuggingFace (e.g., Qwen 2.5 7B)
 computing-provider models download Qwen/Qwen2.5-7B-Instruct
 
-# 4. Start SGLang with the downloaded model
+# 3. Start SGLang with the downloaded model
 docker run -d --gpus all -p 30000:30000 --ipc=host --name sglang \
   -v ~/.swan/models/Qwen/Qwen2.5-7B-Instruct:/models \
   lmsysorg/sglang:latest \
@@ -37,14 +34,14 @@ docker run -d --gpus all -p 30000:30000 --ipc=host --name sglang \
     --host 0.0.0.0 --port 30000 \
     --served-model-name Qwen/Qwen2.5-7B-Instruct
 
-# 5. Run the setup wizard (handles auth, config, and model discovery)
+# 4. Run the setup wizard (handles auth, config, and model discovery)
 computing-provider setup
 
-# 6. Run the provider
+# 5. Run the provider
 computing-provider run
 ```
 
-The `models download` command downloads pre-verified weights from the Swan Model Repository with SHA256 hash checks. The setup wizard will:
+The `models download` command downloads model weights directly from HuggingFace. Large weight files (LFS) are verified with SHA256 hashes. The setup wizard will:
 - Check prerequisites (Docker, GPU)
 - Create/login to your Swan Inference account
 - Auto-discover your running model servers

--- a/build/version.go
+++ b/build/version.go
@@ -12,9 +12,9 @@ var NetWorkTag string
 
 // Inference URL defaults — overridable via ldflags at build time.
 // Production defaults; dev builds override these in the Makefile.
-var DefaultInferenceURL = "https://api.swanchain.io/v1"
-var DefaultInferenceWSURL = "wss://api-ws.swanchain.io"
-var DefaultInferenceAPIURL = "https://api.swanchain.io/v1"
+var DefaultInferenceURL = "https://inference-dev.swanchain.io"
+var DefaultInferenceWSURL = "wss://inference-ws-dev.swanchain.io"
+var DefaultInferenceAPIURL = "https://inference-dev.swanchain.io/api/v1"
 
 const BuildVersion = "0.1.0"
 

--- a/cmd/computing-provider/models.go
+++ b/cmd/computing-provider/models.go
@@ -125,58 +125,50 @@ Examples:
 
 var modelsDownloadCmd = &cli.Command{
 	Name:      "download",
-	Usage:     "Download verified model weights from Swan Model Repository",
+	Usage:     "Download model weights from HuggingFace",
 	ArgsUsage: "<model-id>",
-	Description: `Downloads model weights from the Swan Model Repository (NebulaBlock S3 storage).
-Each file is verified against its SHA256 hash after download. Existing files
-with matching hashes are skipped automatically.
+	Description: `Downloads model weights directly from HuggingFace.
+Files with LFS metadata are verified against their SHA256 hash after download.
+Existing files with matching hashes are skipped automatically.
 
 Examples:
-  computing-provider models download meta-llama/Llama-3.1-8B-Instruct
+  computing-provider models download Qwen/Qwen2.5-7B-Instruct
   computing-provider models download --dest /data/models meta-llama/Llama-3.3-70B-Instruct`,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "dest",
 			Usage: "Destination directory (default: ~/.swan/models/<model-id>)",
 		},
-		&cli.StringFlag{
-			Name:  "service-url",
-			Usage: "Swan Inference API URL (default: from config or " + build.DefaultInferenceURL + ")",
-		},
 	},
 	Action: func(cctx *cli.Context) error {
 		modelID := cctx.Args().First()
 		if modelID == "" {
-			return fmt.Errorf("model ID is required, e.g. meta-llama/Llama-3.1-8B-Instruct")
+			return fmt.Errorf("model ID is required, e.g. Qwen/Qwen2.5-7B-Instruct")
 		}
 
-		serviceURL := cctx.String("service-url")
-		if serviceURL == "" {
-			serviceURL = getModelsServiceURL(cctx)
-		}
-
-		fmt.Printf("Fetching file manifest for %s...\n", modelID)
-		manifest, err := models.FetchModelFiles(serviceURL, modelID)
+		fmt.Printf("Fetching file list from HuggingFace for %s...\n", modelID)
+		files, err := models.FetchHuggingFaceFiles(modelID)
 		if err != nil {
 			return fmt.Errorf("failed to fetch model files: %v", err)
 		}
 
-		if manifest.FileCount == 0 {
-			return fmt.Errorf("no files found for model %s. Has it been ingested?", modelID)
+		if len(files) == 0 {
+			return fmt.Errorf("no files found for model %s on HuggingFace", modelID)
 		}
 
-		// Use canonical model ID from manifest for directory name (ensures correct casing)
 		destDir := cctx.String("dest")
 		if destDir == "" {
-			destDir = filepath.Join(defaultModelsDir(), manifest.ModelID)
+			destDir = filepath.Join(defaultModelsDir(), modelID)
 		}
 
-		fmt.Printf("Model: %s\n", manifest.ModelID)
-		fmt.Printf("Files: %d, Total size: %s\n", manifest.FileCount, humanSizeCP(manifest.TotalSizeBytes))
+		totalSize := models.HuggingFaceModelSize(files)
+		fmt.Printf("Model: %s\n", modelID)
+		fmt.Printf("Files: %d, Total size: %s\n", len(files), humanSizeCP(totalSize))
+		fmt.Printf("Source: HuggingFace (https://huggingface.co/%s)\n", modelID)
 		fmt.Printf("Destination: %s\n\n", destDir)
 
 		ctx := context.Background()
-		if err := models.DownloadModelAndSaveManifest(ctx, modelID, manifest.Files, destDir); err != nil {
+		if err := models.DownloadModelAndSaveManifest(ctx, modelID, files, destDir); err != nil {
 			return err
 		}
 

--- a/internal/models/download.go
+++ b/internal/models/download.go
@@ -126,12 +126,15 @@ func DownloadModel(ctx context.Context, files []ModelFile, destDir string) error
 
 		// Check resume: skip if file exists with matching size and hash
 		if info, err := os.Stat(destPath); err == nil {
-			if info.Size() == f.SizeBytes && f.SizeBytes > 0 {
+			if f.Hash != "" && info.Size() == f.SizeBytes && f.SizeBytes > 0 {
 				hash, err := hashFile(destPath)
 				if err == nil && hash == f.Hash {
 					fmt.Printf("[%d/%d] skip %s (already verified)\n", i+1, len(files), f.Filename)
 					continue
 				}
+			} else if f.Hash == "" && info.Size() > 0 {
+				fmt.Printf("[%d/%d] skip %s (already exists)\n", i+1, len(files), f.Filename)
+				continue
 			}
 		}
 
@@ -141,16 +144,18 @@ func DownloadModel(ctx context.Context, files []ModelFile, destDir string) error
 			return fmt.Errorf("failed to download %s: %w", f.Filename, err)
 		}
 
-		// Verify hash after download
-		hash, err := hashFile(destPath)
-		if err != nil {
-			return fmt.Errorf("failed to hash %s: %w", f.Filename, err)
+		// Verify hash after download (only if expected hash is available)
+		if f.Hash != "" {
+			hash, err := hashFile(destPath)
+			if err != nil {
+				return fmt.Errorf("failed to hash %s: %w", f.Filename, err)
+			}
+			if hash != f.Hash {
+				os.Remove(destPath)
+				return fmt.Errorf("hash mismatch for %s: expected %s, got %s", f.Filename, f.Hash, hash)
+			}
+			fmt.Printf("[%d/%d] verified %s\n", i+1, len(files), f.Filename)
 		}
-		if hash != f.Hash {
-			os.Remove(destPath)
-			return fmt.Errorf("hash mismatch for %s: expected %s, got %s", f.Filename, f.Hash, hash)
-		}
-		fmt.Printf("[%d/%d] verified %s\n", i+1, len(files), f.Filename)
 	}
 
 	return nil
@@ -231,6 +236,7 @@ func downloadFile(ctx context.Context, url, destPath string, expectedSize int64)
 	if err != nil {
 		return err
 	}
+	req.Header.Set("User-Agent", "SwanProvider/2.0")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -240,7 +246,8 @@ func downloadFile(ctx context.Context, url, destPath string, expectedSize int64)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("HTTP %d", resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
 	}
 
 	// Write to temp file first, then rename for atomicity

--- a/internal/models/huggingface.go
+++ b/internal/models/huggingface.go
@@ -1,0 +1,84 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const huggingFaceAPIBase = "https://huggingface.co"
+
+// HFModelInfo is the response from the HuggingFace model API.
+type HFModelInfo struct {
+	Siblings []HFSibling `json:"siblings"`
+}
+
+// HFSibling represents a file in a HuggingFace model repository.
+type HFSibling struct {
+	RFilename string `json:"rfilename"`
+	Size      int64  `json:"size"`
+	LFS       *HFLFS `json:"lfs,omitempty"`
+}
+
+// HFLFS contains LFS metadata for a file.
+type HFLFS struct {
+	SHA256 string `json:"sha256"`
+	Size   int64  `json:"size"`
+}
+
+// FetchHuggingFaceFiles fetches the file list for a model from HuggingFace.
+func FetchHuggingFaceFiles(modelID string) ([]ModelFile, error) {
+	url := fmt.Sprintf("%s/api/models/%s", huggingFaceAPIBase, modelID)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "SwanProvider/2.0")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch from HuggingFace: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("HuggingFace API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var info HFModelInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("failed to parse HuggingFace response: %w", err)
+	}
+
+	files := make([]ModelFile, 0, len(info.Siblings))
+	for _, s := range info.Siblings {
+		f := ModelFile{
+			Filename: s.RFilename,
+			URL:      fmt.Sprintf("%s/%s/resolve/main/%s", huggingFaceAPIBase, modelID, s.RFilename),
+		}
+		if s.LFS != nil {
+			f.Hash = s.LFS.SHA256
+			f.Algorithm = "sha256"
+			f.SizeBytes = s.LFS.Size
+		} else {
+			f.SizeBytes = s.Size
+		}
+		files = append(files, f)
+	}
+
+	return files, nil
+}
+
+// HuggingFaceModelSize returns the total size of all files.
+func HuggingFaceModelSize(files []ModelFile) int64 {
+	var total int64
+	for _, f := range files {
+		total += f.SizeBytes
+	}
+	return total
+}


### PR DESCRIPTION
## Summary
- Switch default inference URLs to dev endpoints
- Download model weights from HuggingFace instead of NebulaBlock S3
- Update README with correct build instructions and config for dev/testnet

## Test plan
- [x] Binary builds with `make testnet`
- [ ] Verify model downloads work from HuggingFace
- [ ] Verify inference connects to dev endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)