### PR TITLE
Revert Makefile and URL defaults, remove unused config fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ PKG=github.com/swanchain/computing-provider-v2/build
 
 ldflags=-X=$(PKG).CurrentCommit=+git.$(subst -,.,$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null))
 
-# Mainnet inference URL overrides
-mainnet_ldflags=-X $(PKG).DefaultInferenceURL=https://api.swanchain.io/v1 \
-                -X $(PKG).DefaultInferenceWSURL=wss://api-ws.swanchain.io \
-                -X $(PKG).DefaultInferenceAPIURL=https://api.swanchain.io/v1
+# Dev/testnet inference URL overrides
+dev_ldflags=-X $(PKG).DefaultInferenceURL=https://inference-dev.swanchain.io \
+            -X $(PKG).DefaultInferenceWSURL=wss://inference-ws-dev.swanchain.io \
+            -X $(PKG).DefaultInferenceAPIURL=https://inference-dev.swanchain.io/api/v1
 
-all: testnet
+all: mainnet
 .PHONY: all
 
 computing-provider:
@@ -30,41 +30,41 @@ clean:
 	sudo rm -rf /usr/local/bin/computing-provider
 .PHONY: clean
 
-testnet: GOFLAGS+= -ldflags="$(ldflags) -X $(PKG).NetWorkTag=testnet"
-testnet: computing-provider
-
-mainnet: GOFLAGS+= -ldflags="$(ldflags) -X $(PKG).NetWorkTag=mainnet $(mainnet_ldflags)"
+mainnet: GOFLAGS+= -ldflags="$(ldflags) -X $(PKG).NetWorkTag=mainnet"
 mainnet: computing-provider
+
+testnet: GOFLAGS+= -ldflags="$(ldflags) -X $(PKG).NetWorkTag=testnet $(dev_ldflags)"
+testnet: computing-provider
 
 # Darwin ARM64 (Apple Silicon) builds
 darwin-arm64:
 	rm -rf computing-provider-darwin-arm64
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=testnet" -o computing-provider-darwin-arm64 ./cmd/computing-provider
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=mainnet" -o computing-provider-darwin-arm64 ./cmd/computing-provider
 .PHONY: darwin-arm64
 
-darwin-arm64-mainnet:
+darwin-arm64-testnet:
 	rm -rf computing-provider-darwin-arm64
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=mainnet $(mainnet_ldflags)" -o computing-provider-darwin-arm64 ./cmd/computing-provider
-.PHONY: darwin-arm64-mainnet
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=testnet $(dev_ldflags)" -o computing-provider-darwin-arm64 ./cmd/computing-provider
+.PHONY: darwin-arm64-testnet
 
 # Linux AMD64 builds
 linux-amd64:
 	rm -rf computing-provider-linux-amd64
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=testnet" -o computing-provider-linux-amd64 ./cmd/computing-provider
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=mainnet" -o computing-provider-linux-amd64 ./cmd/computing-provider
 .PHONY: linux-amd64
 
-linux-amd64-mainnet:
+linux-amd64-testnet:
 	rm -rf computing-provider-linux-amd64
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=mainnet $(mainnet_ldflags)" -o computing-provider-linux-amd64 ./cmd/computing-provider
-.PHONY: linux-amd64-mainnet
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=testnet $(dev_ldflags)" -o computing-provider-linux-amd64 ./cmd/computing-provider
+.PHONY: linux-amd64-testnet
 
 # Linux ARM64 builds
 linux-arm64:
 	rm -rf computing-provider-linux-arm64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=testnet" -o computing-provider-linux-arm64 ./cmd/computing-provider
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=mainnet" -o computing-provider-linux-arm64 ./cmd/computing-provider
 .PHONY: linux-arm64
 
-linux-arm64-mainnet:
+linux-arm64-testnet:
 	rm -rf computing-provider-linux-arm64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=mainnet $(mainnet_ldflags)" -o computing-provider-linux-arm64 ./cmd/computing-provider
-.PHONY: linux-arm64-mainnet
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOCC) build -ldflags="$(ldflags) -X $(PKG).NetWorkTag=testnet $(dev_ldflags)" -o computing-provider-linux-arm64 ./cmd/computing-provider
+.PHONY: linux-arm64-testnet

--- a/build/version.go
+++ b/build/version.go
@@ -11,9 +11,10 @@ var CurrentCommit string
 var NetWorkTag string
 
 // Inference URL defaults — overridable via ldflags at build time.
-var DefaultInferenceURL = "https://inference-dev.swanchain.io"
-var DefaultInferenceWSURL = "wss://inference-ws-dev.swanchain.io"
-var DefaultInferenceAPIURL = "https://inference-dev.swanchain.io/api/v1"
+// Production defaults; dev builds override these in the Makefile.
+var DefaultInferenceURL = "https://api.swanchain.io/v1"
+var DefaultInferenceWSURL = "wss://api-ws.swanchain.io"
+var DefaultInferenceAPIURL = "https://api.swanchain.io/v1"
 
 const BuildVersion = "0.1.1"
 


### PR DESCRIPTION
## Summary
- Revert Makefile target renames and version.go URL defaults
- Remove unused ChainRPC, CollateralContract, TaskContract config fields
- Keep version bump to 0.1.1