### PR TITLE
Fix WebSocket URL defaults and fingerprint regeneration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ NodeName = "my-provider"
 
 [Inference]
 Enable = true
-WebSocketURL = "wss://inference.swanchain.io/ws"
+WebSocketURL = "wss://inference-ws.swanchain.io"
 ApiKey = "sk-prov-xxxxxxxxxxxxxxxxxxxx"  # Your provider API key
 Models = ["meta-llama/Llama-3.2-3B-Instruct"]
 ```

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ NodeName = "my-provider"
 
 [Inference]
 Enable = true
-WebSocketURL = "wss://api-ws.swanchain.io"
+WebSocketURL = "wss://inference-ws.swanchain.io"
 ServiceURL = "https://api.swanchain.io"
 ApiKey = "sk-prov-xxxxxxxxxxxxxxxxxxxx"  # Required - get from https://inference.swanchain.io
 Models = ["qwen-2.5-7b"]

--- a/build/version.go
+++ b/build/version.go
@@ -13,7 +13,7 @@ var NetWorkTag string
 // Inference URL defaults — overridable via ldflags at build time.
 // Production defaults; dev builds override these in the Makefile.
 var DefaultInferenceURL = "https://api.swanchain.io"
-var DefaultInferenceWSURL = "wss://api-ws.swanchain.io"
+var DefaultInferenceWSURL = "wss://inference-ws.swanchain.io"
 var DefaultInferenceAPIURL = "https://api.swanchain.io/api/v1"
 var DefaultInferenceDashboardURL = "https://inference.swanchain.io"
 

--- a/internal/computing/provider.go
+++ b/internal/computing/provider.go
@@ -142,8 +142,8 @@ func CheckMachineIdentity(cpRepoPath string) error {
 			return fmt.Errorf("failed to remove old private_key: %w", err)
 		}
 		logs.GetLogger().Infof("Removed old private_key. A new node-id will be generated on startup.")
-		// Do NOT write fingerprint — GenerateNodeID will create a new key,
-		// and the fingerprint will be written on the next startup.
+		// Write current machine fingerprint so the next startup won't trigger mismatch again
+		_ = os.WriteFile(fingerprintPath, []byte(currentFingerprint), 0644)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- Fix default WebSocket URL to `wss://inference-ws.swanchain.io` across docs, README, and build defaults
- Fix fingerprint regeneration bug: write current machine fingerprint after removing old private_key so next startup doesn't trigger mismatch again

## Test plan
- [ ] Verify new provider connects to correct WebSocket URL with default config
- [ ] Test copied private_key detection and regeneration flow on a second machine